### PR TITLE
Allow 30 items for `not-in` `in` and `array-contains-any`

### DIFF
--- a/mock_constructors/FirestoreMock.js
+++ b/mock_constructors/FirestoreMock.js
@@ -285,6 +285,8 @@ function serializeArray(array) {
   return serialized_array;
 }
 
+const MAX_COMPLEXITY = 30;
+
 const operators = {
   "==": function(field, value) {
     if (field && field.constructor.name === "TimestampMock") {
@@ -378,7 +380,7 @@ const operators = {
       throw new Error("The 'in' filter operator requires an array of values");
     }
 
-    if (values.length > 10) {
+    if (values.length > MAX_COMPLEXITY) {
       throw new Error(
         "Firestore only allows up to 10 values to be filtered in an 'in' filter"
       );
@@ -402,7 +404,7 @@ const operators = {
       throw new Error("The 'not-in' filter operator requires an array of values");
     }
 
-    if (values.length > 10) {
+    if (values.length > MAX_COMPLEXITY) {
       throw new Error(
         "Firestore only allows up to 10 values to be filtered in a 'not-in' filter"
       );
@@ -428,7 +430,7 @@ const operators = {
       );
     }
 
-    if (values.length > 10) {
+    if (values.length > MAX_COMPLEXITY) {
       throw new Error(
         "Firestore only allows up to 10 values to be filtered in an 'array-contains-any' filter"
       );

--- a/test/firestore_instance.test.js
+++ b/test/firestore_instance.test.js
@@ -532,12 +532,12 @@ describe("Testing the firestore _where method with the in filter", () => {
     });
   });
 
-  it("Errors when more than 10 queries are provided", () => {
+  it("Errors when more than 30 queries are provided", () => {
     function error() {
       return firestore._where(
         "date",
         "in",
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        Array.from(Array(31).keys()),
         undefined,
         "Coll1"
       );
@@ -609,7 +609,7 @@ describe("Testing the 'array-contains-any' filter", () => {
       return firestore._where(
         "date",
         "array-contains-any",
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        Array.from(Array(31).keys()),
         undefined,
         "Coll1"
       );


### PR DESCRIPTION
See https://firebase.google.com/docs/firestore/query-data/queries#limitations_2

It was changed to allow 30 changes.